### PR TITLE
Correção da marcação e estilo do módulo Jumbotron #25

### DIFF
--- a/jumbotron/index.html
+++ b/jumbotron/index.html
@@ -1,11 +1,13 @@
 <section class="module jumbotron">
   <h1>
-    <img src="jumbotron/img/logo-avante.svg" alt="Avante | Estúdio de Tecnologia"/>
+    <img class="logo" src="jumbotron/img/logo-avante.svg" alt="Avante | Estúdio de Tecnologia"/>
   </h1>
-  
-  <span class="moto">Estúdio de Tecnologia</span>
 
-  <img src="jumbotron/img/jumbotron01.jpg" alt="Imagem de fundo"/>
-  <img src="jumbotron/img/jumbotron02.jpg" alt="Imagem de fundo"/>
-  <img src="jumbotron/img/jumbotron03.jpg" alt="Imagem de fundo"/>
+  <div class="moto">Estúdio de Tecnologia</div>
+
+  <div class="slider">
+    <figure><img src="jumbotron/img/jumbotron01.jpg" alt="Imagem de fundo"/></figure>
+    <figure><img src="jumbotron/img/jumbotron02.jpg" alt="Imagem de fundo"/></figure>
+    <figure><img src="jumbotron/img/jumbotron03.jpg" alt="Imagem de fundo"/></figure>
+  </div>
 </section>

--- a/jumbotron/styles.css
+++ b/jumbotron/styles.css
@@ -1,0 +1,61 @@
+.module.jumbotron {
+  height: 100vh;
+  position: relative;
+  width: 100%;
+  z-index: 0;
+}
+
+.module.jumbotron:after {
+  background-color: rgba(0, 0, 0, .44);
+  content: '';
+  height: 100%;
+  left: 0;
+  position: absolute;
+  top: 0;
+  width: 100%;
+  z-index: 1;
+}
+
+.module.jumbotron .logo {
+  height: 100%;
+  left: 0;
+  position: absolute;
+  top: 0;
+  width: 100%;
+  z-index: 2;
+}
+
+.module.jumbotron .moto {
+  color: #fff;
+  font: 48pt 'Open Sans';
+  left: 0;
+  position: absolute;
+  text-align: center;
+  top: calc(50% + 1em);
+  width: 100%;
+  z-index: 2;
+}
+
+.module.jumbotron .slider {
+  height: 100%;
+  left: 0;
+  overflow: hidden;
+  position: absolute;
+  top: 0;
+  width: 100%;
+  z-index: 0;
+}
+
+.module.jumbotron .slider figure {
+  height: 100%;
+  left: 0;
+  opacity: 0;
+  position: absolute;
+  top: 0;
+  width: 100%;
+  z-index: 0;
+}
+
+.module.jumbotron .slider figure:first-child {
+  opacity: 1;
+}


### PR DESCRIPTION
- Troquei o span do logo por uma div
- Envolvi as imagens com figures dentro de um conteiner (slider)
- Alterei o CSS para se adequar a essas mudanças
